### PR TITLE
Bug Fix // Typer Component: destroy on route transition

### DIFF
--- a/src/components/Typer.jsx
+++ b/src/components/Typer.jsx
@@ -33,7 +33,6 @@ class Typer extends Component {
     await timeout(delay);
     let key;
 
-
     for (var i = 0; i < text.length ; i++) {
       await timeout(interval);
       if (!this.mounted) { return; }
@@ -41,13 +40,22 @@ class Typer extends Component {
 
       if (text[i] === " ") {
         this.spacebar.play()
-      } else if (key === 1) {
-        this.slowkey.play();
-      } else if (key === 2) {
-        this.fastkey.play();
       } else {
-        this.midkey.play();
+        switch (key) {
+          case 1:
+            this.slowkey.play();
+            break;
+          case 2:
+            this.fastkey.play();
+            break;
+          case 3:
+            this.midkey.play();
+            break;
+          default:
+            break;
+        }
       }
+
 
       let show = this.state.show;
       show += text[i];

--- a/src/components/Typer.jsx
+++ b/src/components/Typer.jsx
@@ -12,6 +12,7 @@ class Typer extends Component {
     this.slowkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_slow1.wav');
     this.fastkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_fast1.wav');
     this.midkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_enter.wav');
+    this.mounted = true;
   }
 
   componentDidMount() {
@@ -35,7 +36,7 @@ class Typer extends Component {
 
     for (var i = 0; i < text.length ; i++) {
       await timeout(interval);
-
+      if (!this.mounted) { return; }
       key = Math.floor(Math.random() * 3) + 1;
 
       if (text[i] === " ") {

--- a/src/components/Typer.jsx
+++ b/src/components/Typer.jsx
@@ -8,6 +8,10 @@ class Typer extends Component {
     this.state = {
       show: ""
     }
+    this.spacebar = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_space.wav');
+    this.slowkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_slow1.wav');
+    this.fastkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_fast1.wav');
+    this.midkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_enter.wav');
   }
 
   componentDidMount() {
@@ -19,10 +23,7 @@ class Typer extends Component {
     const timeout = ms => new Promise(res => setTimeout(res, ms));
     await timeout(delay);
     let key;
-    var spacebar = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_space.wav');
-    var slowkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_slow1.wav');
-    var fastkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_fast1.wav');
-    var midkey = new Audio('https://raw.githubusercontent.com/yingDev/Tickeys/master/Tickeys.app/Contents/Resources/data/Cherry_G80_3494/G80-3494_enter.wav');
+
 
     for (var i = 0; i < text.length ; i++) {
       await timeout(interval);
@@ -30,13 +31,13 @@ class Typer extends Component {
       key = Math.floor(Math.random() * 3) + 1;
 
       if (text[i] === " ") {
-        spacebar.play()
+        this.spacebar.play()
       } else if (key === 1) {
-        slowkey.play();
+        this.slowkey.play();
       } else if (key === 2) {
-        fastkey.play();
+        this.fastkey.play();
       } else {
-        midkey.play();
+        this.midkey.play();
       }
 
       let show = this.state.show;

--- a/src/components/Typer.jsx
+++ b/src/components/Typer.jsx
@@ -19,6 +19,14 @@ class Typer extends Component {
     this._animateType(text, delay, interval);
   }
 
+  componentWillUnmount() {
+    this.spacebar.pause();
+    this.slowkey.pause();
+    this.fastkey.pause();
+    this.midkey.pause();
+    this.mounted = false;
+  }
+
   async _animateType(text, delay, interval) {
     const timeout = ms => new Promise(res => setTimeout(res, ms));
     await timeout(delay);


### PR DESCRIPTION
- the Audio objects are now at the component constructor level, instead of being created every time in the async/await loop
- handle the component unmounting, stopping all of the future await loops from playing sounds
- using a 'ismounted' property at the component's constructor level, need to look into whether or not this is still the acceptable practice (see the example here https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html)
- updated some syntax